### PR TITLE
chore: Runs CI on pull request

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   push:
     paths-ignore:
       - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
     paths-ignore:
       - '**.md'
-    
+
 jobs:
   build:
     runs-on: ubuntu-18.04
@@ -14,7 +14,5 @@ jobs:
 
       - name: test
         run: |
-         git clone -b "${GITHUB_REF#refs/heads/}" https://github.com/ryuichiueda/glueutils
-         cd ./glueutils
          make
          ./test/test_all.bash


### PR DESCRIPTION
- `actions/checkout@v2` を使っているので git clone が不要だったので削除
  - また、git clone + cd した先でテストを実行すると、それは master ブランチのテストしか走らないため、ブランチ毎でCIのテストを走らせても常に master ブランチしかテストされなくなっていました
- Pull Requestが作成された時もCIでテストするようにしました